### PR TITLE
Fix regexp warnings in perl 5.28.

### DIFF
--- a/lib/Bio/ASN1/EntrezGene.pm
+++ b/lib/Bio/ASN1/EntrezGene.pm
@@ -253,7 +253,7 @@ sub next_seq
   {
     chomp;
     next unless /\S/;
-    my $tmp = (/^\s*Entrezgene(-Set)? ::= ({.*)/si)? $2 : "{" . $_; # get rid of the 'Entrezgene ::= ' at the beginning of Entrez Gene record
+    my $tmp = (/^\s*Entrezgene(-Set)? ::= (\{.*)/si)? $2 : "{" . $_; # get rid of the 'Entrezgene ::= ' at the beginning of Entrez Gene record
     return $self->parse($tmp, $compact, 1); # 1 species no resetting line number
   }
 }

--- a/lib/Bio/ASN1/Sequence.pm
+++ b/lib/Bio/ASN1/Sequence.pm
@@ -239,7 +239,7 @@ sub next_seq
   {
     chomp;
     next unless /\S/;
-    my $tmp = (/^\s*Seq-entry ::= set ({.*)/si)? $1 : "{" . $_; # get rid of the 'Seq-entry ::= set ' at the beginning of Sequence record
+    my $tmp = (/^\s*Seq-entry ::= set (\{.*)/si)? $1 : "{" . $_; # get rid of the 'Seq-entry ::= set ' at the beginning of Sequence record
     return $self->parse($tmp, $compact, 1); # 1 species no resetting line number
   }
 }


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Bio-ASN1-EntrezGene.
We thought you might be interested in it too.

    Description: Fix regexp warnings in perl 5.28.
     Unescaped left brace in regex is deprecated here (and will be fatal in Perl 5.32), passed through in regex; marked by <-- HERE in m/^\s*Entrezgene(-Set)? ::= ({ <-- HERE .*)/ at /build/libbio-asn1-entrezgene-perl-1.720/blib/lib/Bio/ASN1/EntrezGene.pm line 91.
     Unescaped left brace in regex is deprecated here (and will be fatal in Perl 5.32), passed through in regex; marked by <-- HERE in m/^\s*Seq-entry ::= set ({ <-- HERE .*)/ at /build/libbio-asn1-entrezgene-perl-1.720/blib/lib/Bio/ASN1/Sequence.pm line 91.
    Origin: vendor
    Bug-Debian: https://bugs.debian.org/903294
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2018-07-08
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libbio-asn1-entrezgene-perl/raw/master/debian/patches/unescaped_left_brace-5.28.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
