### PR TITLE
fix spelling mistakes

### DIFF
--- a/lib/Bio/ASN1/EntrezGene.pm
+++ b/lib/Bio/ASN1/EntrezGene.pm
@@ -237,7 +237,7 @@ sub input_file
                 please see comment for the trimdata method. An option
                 of 2 is recommended and default
               The acceptable values for $trimopt include:
-                1 - trim as much as possibile
+                1 - trim as much as possible
                 2 (or 0, undef) - trim to an easy-to-use structure
                 3 - no trimming (in version 1.06, prior to version
                     1.06, 0 or undef means no trimming)
@@ -424,7 +424,7 @@ sub _parse
   Notes:      This function is useful to compact a data structure produced by
                 Bio::ASN1::EntrezGene::parse.
               The acceptable values for $trimopt include:
-                1 - trim as much as possibile
+                1 - trim as much as possible
                 2 (or 0, undef) - trim to an easy-to-use structure
                 3 - no trimming (in version 1.06, prior to version
                     1.06, 0 or undef means no trimming)

--- a/lib/Bio/ASN1/Sequence.pm
+++ b/lib/Bio/ASN1/Sequence.pm
@@ -223,7 +223,7 @@ sub input_file
                 please see comment for the trimdata method. An option
                 of 2 is recommended and default
               The acceptable values for $trimopt include:
-                1 - trim as much as possibile
+                1 - trim as much as possible
                 2 (or 0, undef) - trim to an easy-to-use structure
                 3 - no trimming (in version 1.06, prior to version
                     1.06, 0 or undef means no trimming)
@@ -417,7 +417,7 @@ sub _parse
   Notes:      This function is useful to compact a data structure produced by
                 Bio::ASN1::Sequence::parse.
               The acceptable values for $trimopt include:
-                1 - trim as much as possibile
+                1 - trim as much as possible
                 2 (or 0, undef) - trim to an easy-to-use structure
                 3 - no trimming (in version 1.06, prior to version
                     1.06, 0 or undef means no trimming)


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Bio-ASN1-EntrezGene.
We thought you might be interested in it too.

    Description: fix spelling mistakes
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2018-07-08
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libbio-asn1-entrezgene-perl/raw/master/debian/patches/spelling.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
